### PR TITLE
changed Xcom_push to use context["ti"] instead of self

### DIFF
--- a/src/PowerBI_Operator/hooks/powerbi_hook.py
+++ b/src/PowerBI_Operator/hooks/powerbi_hook.py
@@ -3,7 +3,7 @@ from typing import Union
 
 import requests  # type: ignore
 from airflow.exceptions import AirflowException
-from airflow.hooks.base import BaseHook
+from airflow.sdk.bases.hook import BaseHook
 from azure.identity import ClientSecretCredential
 
 from PowerBI_Operator.models.powerbi_models import PowerBIDatasetRefreshException, PowerBiDatasetRefreshDetails

--- a/src/PowerBI_Operator/operators/powerbi_refresh_dataset_operator.py
+++ b/src/PowerBI_Operator/operators/powerbi_refresh_dataset_operator.py
@@ -66,8 +66,7 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
         Refresh the Power BI Dataset
         """
         request_id = self.hook.trigger_dataset_refresh(self.wait_for_termination)
-        self.xcom_push(
-            context=context,
+        context["ti"].xcom_push(
             key="powerbi_dataset_refresh_id",
             value=request_id
         )

--- a/src/PowerBI_Operator/sensors/powerbi_refresh_dataset_sensor.py
+++ b/src/PowerBI_Operator/sensors/powerbi_refresh_dataset_sensor.py
@@ -1,4 +1,4 @@
-from airflow.sensors.base import BaseSensorOperator
+from airflow.sdk.bases.sensor import BaseSensorOperator
 
 from PowerBI_Operator.hooks.powerbi_hook import PowerBIHook
 from PowerBI_Operator.models.powerbi_models import PowerBIDatasetRefreshException, PowerBiDatasetRefreshDetails


### PR DESCRIPTION
changed import of BaseHook and BaseSensorOperator to airflow.sdk.bases because of deprication warnings.