### PR TITLE
Bump version to 1.1.3; register Power BI as a declarative connection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-powerbi-provider"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
   { name="Glenn Schuurman", email="info@schuurman-it.com" },
   { name= "Michael Schuurman", email="info@schuurman-it.com" }
@@ -17,12 +17,18 @@ classifiers = [
     "License :: OSI Approved :: MIT License"
 ]
 dependencies = [
-    "apache-airflow>=2.10.0",
+    "apache-airflow>=3.0.0",
     "azure-identity>=1.17.1"
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/PowerBI_Operator"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/PowerBI_Operator/provider.yaml" = "PowerBI_Operator/provider.yaml"
+
+[project.entry-points."apache_airflow_provider"]
+provider_info = "PowerBI_Operator.get_provider_info:get_provider_info"
 
 [project.urls]
 Homepage = "https://github.com/gschuurman/airflow-powerbi-provider"

--- a/src/PowerBI_Operator/get_provider_info.py
+++ b/src/PowerBI_Operator/get_provider_info.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from importlib.metadata import version
+from importlib.resources import files
+
+
+def get_provider_info():
+    import yaml
+
+    package_name = "airflow-powerbi-provider"
+    text = files("PowerBI_Operator").joinpath("provider.yaml").read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    data["versions"] = [version(package_name)]
+    return data

--- a/src/PowerBI_Operator/hooks/powerbi_hook.py
+++ b/src/PowerBI_Operator/hooks/powerbi_hook.py
@@ -16,6 +16,9 @@ class PowerBIHook(BaseHook):
     :param dataset_id: The dataset id.
     :param group_id: The workspace id.
     """
+    conn_type: str = "power_bi"
+    conn_name_attr: str = "conn_id"
+    default_conn_name: str = "powerbi_default"
     hook_name: str = "Power BI"
 
     def __init__(

--- a/src/PowerBI_Operator/provider.yaml
+++ b/src/PowerBI_Operator/provider.yaml
@@ -1,0 +1,27 @@
+package-name: airflow-powerbi-provider
+name: Power BI
+description: Apache Airflow provider for Microsoft Power BI dataset refresh.
+versions:
+  - "1.1.3"
+
+connection-types:
+  - hook-class-name: PowerBI_Operator.hooks.powerbi_hook.PowerBIHook
+    connection-type: power_bi
+    conn-fields:
+      tenant_id:
+        label: Tenant ID
+        schema:
+          type: [string, "null"]
+    ui-field-behaviour:
+      hidden-fields:
+        - schema
+        - port
+        - host
+        - extra
+      relabeling:
+        login: Client ID
+        password: Client Secret
+      placeholders:
+        login: "Azure AD app (service principal) client ID"
+        password: "Azure AD app client secret"
+        tenant_id: "00000000-0000-0000-0000-000000000000"

--- a/tests/operators/test_powerbi_refresh_dataset_operator.py
+++ b/tests/operators/test_powerbi_refresh_dataset_operator.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from airflow.utils.context import Context
 from PowerBI_Operator.hooks.powerbi_hook import PowerBIHook
 from PowerBI_Operator.operators.powerbi_refresh_dataset_operator import PowerBIDatasetRefreshOperator
 
@@ -21,8 +20,7 @@ class TestPowerBIDatasetRefreshOperator(unittest.TestCase):
             wait_for_termination=True
         )
 
-        context = MagicMock(spec=Context)
-        context.xcom_push = MagicMock()  # Ensure the mock context has xcom_push method
+        context = {"ti": MagicMock()}
 
         operator.execute(context)
 


### PR DESCRIPTION
Registers PowerBIHook as a proper Airflow provider with a declarative provider.yaml so connection form metadata is served without importing hook modules, eliminating the api-server CPU/memory spike on connection dialog open.

Changes:
- Add conn_type, conn_name_attr, and default_conn_name class attributes to PowerBIHook (were missing; hook was not registered as a connection type)
- Add get_provider_info.py and apache_airflow_provider entry-point so Airflow discovers the provider package
- Add provider.yaml with conn-fields (tenant_id) and ui-field-behaviour (hidden fields, Client ID/Secret relabeling, placeholders) for power_bi
- Register provider.yaml in the wheel via pyproject.toml force-include
- Bump apache-airflow dependency from >=2.10.0 to >=3.0.0 (required for declarative provider.yaml connection type support)