### PR TITLE
Bump version to 1.1.4; support both tenant_id and tenantId; complete …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-powerbi-provider"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="Glenn Schuurman", email="info@schuurman-it.com" },
   { name= "Michael Schuurman", email="info@schuurman-it.com" }

--- a/src/PowerBI_Operator/__init__.py
+++ b/src/PowerBI_Operator/__init__.py
@@ -1,0 +1,1 @@
+"""Apache Airflow provider for Microsoft Power BI dataset refresh."""

--- a/src/PowerBI_Operator/_autodoc.py
+++ b/src/PowerBI_Operator/_autodoc.py
@@ -1,0 +1,8 @@
+"""Manifest of modules worth generating API reference pages for, consumed by product-site's docs build."""
+
+AUTODOC_TARGETS: list[str] = [
+    "PowerBI_Operator.hooks.powerbi_hook",
+    "PowerBI_Operator.models.powerbi_models",
+    "PowerBI_Operator.operators.powerbi_refresh_dataset_operator",
+    "PowerBI_Operator.sensors.powerbi_refresh_dataset_sensor",
+]

--- a/src/PowerBI_Operator/get_provider_info.py
+++ b/src/PowerBI_Operator/get_provider_info.py
@@ -1,3 +1,4 @@
+"""Airflow provider metadata entrypoint, referenced from ``pyproject.toml``."""
 from __future__ import annotations
 
 from importlib.metadata import version
@@ -5,6 +6,15 @@ from importlib.resources import files
 
 
 def get_provider_info():
+    """
+    Load and return this package's provider metadata for Airflow's provider discovery.
+
+    Reads ``provider.yaml`` and stamps in the installed package version, so
+    Airflow's UI and CLI can report connection types, hooks, and version info
+    without a hardcoded copy.
+
+    :return: Provider metadata dict as consumed by Airflow's provider manager.
+    """
     import yaml
 
     package_name = "airflow-powerbi-provider"

--- a/src/PowerBI_Operator/hooks/__init__.py
+++ b/src/PowerBI_Operator/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Hooks for authenticating and calling the Power BI REST API."""

--- a/src/PowerBI_Operator/hooks/powerbi_hook.py
+++ b/src/PowerBI_Operator/hooks/powerbi_hook.py
@@ -1,3 +1,4 @@
+"""Hook for triggering and monitoring Power BI dataset refreshes."""
 import time
 from typing import Union
 
@@ -27,6 +28,19 @@ class PowerBIHook(BaseHook):
             dataset_id: str,
             group_id: str,
     ):
+        """
+        Initialize the hook with a connection id and target dataset/workspace.
+
+        :param conn_id: Airflow connection id holding the Power BI service principal
+            credentials (client id as login, client secret as password, tenant id
+            in ``extra`` under either ``tenant_id`` or ``tenantId``).
+        :param dataset_id: The dataset id.
+        :param group_id: The workspace id.
+
+        Example::
+
+            hook = PowerBIHook(conn_id="powerbi_default", dataset_id="abc123", group_id="def456")
+        """
         self.conn_id = conn_id
         self.dataset_id = dataset_id
         self.group_id = group_id
@@ -58,14 +72,15 @@ class PowerBIHook(BaseHook):
         connection = self.get_connection(self.conn_id)
         client_id = connection.login
         client_secret = connection.password
-        tenant_id = connection.extra_dejson.get("tenant_id")
+        extra = connection.extra_dejson
+        tenant_id = extra.get("tenant_id") or extra.get("tenantId")
 
         if not client_id:
             raise ValueError("The login is missing")
         if not client_secret:
             raise ValueError("The password is missing")
         if not tenant_id:
-            raise ValueError("The key tenant_id is missing in the extra field")
+            raise ValueError("The key tenant_id (or tenantId) is missing in the extra field")
 
         credential = ClientSecretCredential(
             client_id=client_id,

--- a/src/PowerBI_Operator/models/__init__.py
+++ b/src/PowerBI_Operator/models/__init__.py
@@ -1,0 +1,1 @@
+"""Data models and exceptions shared across the Power BI hook, operator, and sensor."""

--- a/src/PowerBI_Operator/models/powerbi_models.py
+++ b/src/PowerBI_Operator/models/powerbi_models.py
@@ -1,3 +1,4 @@
+"""Data models for Power BI dataset refresh results."""
 from dataclasses import dataclass
 
 from airflow.exceptions import AirflowException
@@ -5,6 +6,14 @@ from airflow.exceptions import AirflowException
 
 @dataclass
 class PowerBiDatasetRefreshDetails:
+    """
+    Details of a single Power BI dataset refresh, as returned by the refresh history API.
+
+    :param request_id: Request id of the dataset refresh.
+    :param status: Refresh status, e.g. ``"Completed"``, ``"Failed"``, or ``"Unknown"`` while in progress.
+    :param end_time: Timestamp the refresh finished, or ``None`` if still running.
+    :param error: Error details if the refresh failed, otherwise ``None``.
+    """
     request_id: str
     status: str
     end_time: str | None

--- a/src/PowerBI_Operator/operators/__init__.py
+++ b/src/PowerBI_Operator/operators/__init__.py
@@ -1,0 +1,1 @@
+"""Operators for triggering Power BI dataset refreshes."""

--- a/src/PowerBI_Operator/operators/powerbi_refresh_dataset_operator.py
+++ b/src/PowerBI_Operator/operators/powerbi_refresh_dataset_operator.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from airflow.models import BaseOperator
 from airflow.models import BaseOperatorLink  # type: ignore
-from airflow.utils.context import Context
+from airflow.sdk.definitions.context import Context
 
 from PowerBI_Operator.hooks.powerbi_hook import PowerBIHook
 
@@ -42,6 +42,26 @@ class PowerBIDatasetRefreshOperator(BaseOperator):
             *args,
             **kwargs,
     ) -> None:
+        """
+        Initialize the operator with connection, target dataset, and wait behavior.
+
+        :param conn_id: Airflow connection id holding the Power BI service principal credentials.
+        :param dataset_id: The dataset id.
+        :param group_id: The workspace id.
+        :param wait_for_termination: Wait until the pre-existing or current triggered refresh completes before exiting.
+        :param timeout: Time in seconds to wait for a dataset to reach a terminal status. Used only if ``wait_for_termination`` is True.
+        :param check_interval: Number of seconds to wait before rechecking the refresh status.
+
+        Example::
+
+            PowerBIDatasetRefreshOperator(
+                task_id="refresh_dataset",
+                conn_id="powerbi_default",
+                dataset_id="abc123",
+                group_id="def456",
+                wait_for_termination=True,
+            )
+        """
         super(PowerBIDatasetRefreshOperator, self).__init__(*args, **kwargs)
         self.conn_id = conn_id
         self.dataset_id = dataset_id

--- a/src/PowerBI_Operator/provider.yaml
+++ b/src/PowerBI_Operator/provider.yaml
@@ -2,7 +2,7 @@ package-name: airflow-powerbi-provider
 name: Power BI
 description: Apache Airflow provider for Microsoft Power BI dataset refresh.
 versions:
-  - "1.1.3"
+  - "1.1.4"
 
 connection-types:
   - hook-class-name: PowerBI_Operator.hooks.powerbi_hook.PowerBIHook

--- a/src/PowerBI_Operator/sensors/__init__.py
+++ b/src/PowerBI_Operator/sensors/__init__.py
@@ -1,0 +1,1 @@
+"""Sensors for polling the status of a Power BI dataset refresh."""

--- a/src/PowerBI_Operator/sensors/powerbi_refresh_dataset_sensor.py
+++ b/src/PowerBI_Operator/sensors/powerbi_refresh_dataset_sensor.py
@@ -1,3 +1,4 @@
+"""Sensor for polling the status of a previously triggered Power BI dataset refresh."""
 from airflow.sdk.bases.sensor import BaseSensorOperator
 
 from PowerBI_Operator.hooks.powerbi_hook import PowerBIHook
@@ -5,6 +6,28 @@ from PowerBI_Operator.models.powerbi_models import PowerBIDatasetRefreshExceptio
 
 
 class PowerBIDatasetRefreshSensor(BaseSensorOperator):
+    """
+    Polls a Power BI dataset refresh, started by an upstream task, until it terminates.
+
+    The refresh request id is read from XCom, pushed by the upstream task
+    (typically a :class:`~PowerBI_Operator.operators.powerbi_refresh_dataset_operator.PowerBIDatasetRefreshOperator`
+    run with ``wait_for_termination=False``) under the key ``powerbi_dataset_refresh_id``.
+
+    :param conn_id: Airflow connection id holding the Power BI service principal credentials.
+    :param dataset_id: The dataset id.
+    :param group_id: The workspace id.
+    :param xcom_task_id: Task id of the upstream task that pushed the refresh request id to XCom.
+
+    Example::
+
+        PowerBIDatasetRefreshSensor(
+            task_id="wait_for_refresh",
+            conn_id="powerbi_default",
+            dataset_id="abc123",
+            group_id="def456",
+            xcom_task_id="refresh_dataset",
+        )
+    """
     def __init__(
             self,
             conn_id,
@@ -14,6 +37,14 @@ class PowerBIDatasetRefreshSensor(BaseSensorOperator):
             *args,
             **kwargs,
     ):
+        """
+        Initialize the sensor with connection, target dataset, and the upstream XCom source.
+
+        :param conn_id: Airflow connection id holding the Power BI service principal credentials.
+        :param dataset_id: The dataset id.
+        :param group_id: The workspace id.
+        :param xcom_task_id: Task id of the upstream task that pushed the refresh request id to XCom.
+        """
         super(PowerBIDatasetRefreshSensor, self).__init__(*args, **kwargs)
         self.dataset_id = dataset_id
         self.group_id = group_id
@@ -21,6 +52,16 @@ class PowerBIDatasetRefreshSensor(BaseSensorOperator):
         self.xcom_task_id = xcom_task_id
 
     def poke(self, context):
+        """
+        Check whether the dataset refresh has reached a terminal status.
+
+        Pushes the terminal status to XCom under ``powerbi_dataset_refresh_status``
+        and raises :class:`~PowerBI_Operator.models.powerbi_models.PowerBIDatasetRefreshException`
+        if the refresh failed.
+
+        :param context: Airflow task instance context, used to pull the refresh request id from XCom.
+        :return: ``True`` once the refresh has reached a terminal status (``Failed`` or ``Completed``).
+        """
         hook = PowerBIHook(
             conn_id=self.conn_id,
             dataset_id=self.dataset_id,

--- a/tests/hooks/test_powerbi_hook.py
+++ b/tests/hooks/test_powerbi_hook.py
@@ -93,6 +93,45 @@ class TestPowerBIHook(unittest.TestCase):
         self.assertEqual(request_id, 'test_request_id')
         mock_wait_for_dataset_refresh_status.assert_called_once()
 
+    @patch('PowerBI_Operator.hooks.powerbi_hook.ClientSecretCredential')
+    @patch('PowerBI_Operator.hooks.powerbi_hook.PowerBIHook.get_connection')
+    def test_get_token_accepts_snake_case_tenant_id(self, mock_get_connection, mock_credential):
+        mock_get_connection.return_value = MagicMock(
+            login='client_id', password='client_secret',
+            extra_dejson={'tenant_id': 'tenant-snake'}
+        )
+        mock_credential.return_value.get_token.return_value = MagicMock(token='test_token')
+
+        self.hook._get_token()
+
+        mock_credential.assert_called_once_with(
+            client_id='client_id', client_secret='client_secret', tenant_id='tenant-snake'
+        )
+
+    @patch('PowerBI_Operator.hooks.powerbi_hook.ClientSecretCredential')
+    @patch('PowerBI_Operator.hooks.powerbi_hook.PowerBIHook.get_connection')
+    def test_get_token_accepts_camel_case_tenant_id(self, mock_get_connection, mock_credential):
+        mock_get_connection.return_value = MagicMock(
+            login='client_id', password='client_secret',
+            extra_dejson={'tenantId': 'tenant-camel'}
+        )
+        mock_credential.return_value.get_token.return_value = MagicMock(token='test_token')
+
+        self.hook._get_token()
+
+        mock_credential.assert_called_once_with(
+            client_id='client_id', client_secret='client_secret', tenant_id='tenant-camel'
+        )
+
+    @patch('PowerBI_Operator.hooks.powerbi_hook.PowerBIHook.get_connection')
+    def test_get_token_raises_when_tenant_id_missing(self, mock_get_connection):
+        mock_get_connection.return_value = MagicMock(
+            login='client_id', password='client_secret', extra_dejson={}
+        )
+
+        with self.assertRaises(ValueError):
+            self.hook._get_token()
+
     @patch('PowerBI_Operator.hooks.powerbi_hook.requests.post')
     @patch('PowerBI_Operator.hooks.powerbi_hook.requests.get')
     @patch('PowerBI_Operator.hooks.powerbi_hook.PowerBIHook._get_token')


### PR DESCRIPTION
…docstrings and autodoc manifest

- PowerBIHook now accepts tenant_id or tenantId in connection extra, so a connection's extra JSON can be shared with the Fabric provider.
- Filled in missing docstrings across the package and added _autodoc.py with AUTODOC_TARGETS for product-site's docs build.
- Replaced deprecated airflow.utils.context.Context import with airflow.sdk.definitions.context.Context.